### PR TITLE
Fixed bugs when plotted chromosomes other than chromosome 1.

### DIFF
--- a/R/rGMAP_source.R
+++ b/R/rGMAP_source.R
@@ -1503,6 +1503,9 @@ refm_hic = cmpfun(refm_hic)
 plotdom <- function(hic_dat, hiertads_gmap, start_bin, end_bin, cthr = 20, resl = 10000){
 
   if(dim(hic_dat)[1] == dim(hic_dat)[2]) hic_dat = data.table(refm_hic(hic_dat))
+  
+  if (ncol(hiertads_gmap) == 4) #if TADs called from multiple chromosomes, assuming the first col should be chr, cut it.
+    hiertads_gmap = hiertads_gmap[,-1]
 
   names(hiertads_gmap) = c('start', 'end', 'dom_order')
   names(hic_dat) = c('n1', 'n2', 'count')

--- a/R/rGMAP_source.R
+++ b/R/rGMAP_source.R
@@ -1552,7 +1552,7 @@ plotdom <- function(hic_dat, hiertads_gmap, start_bin, end_bin, cthr = 20, resl 
 
   ss = ifelse(resl == 1, 1, 10^6/resl)  ## plot in scale of mb
   xlab0 = ifelse(resl == 1, 'bin', 'Mb')
-  hdat$n1 = hdat$n1/ss
+  hdat$n1 = (hdat$n1 - as.numeric(as.vector(hic_dat[1, 1])) + 1)/ss
 
   orgPlot <- ggplot(data = hdat, aes(n1, n2)) + geom_point(aes(colour = count)) +
     scale_colour_gradient(high = 'red', low = 'white') + xlim(min(hdat$n1), max(hdat$n1)) +
@@ -1567,7 +1567,8 @@ plotdom <- function(hic_dat, hiertads_gmap, start_bin, end_bin, cthr = 20, resl 
 
 
 
-  orgWTad_horz <- function(xy, m = mm, M = MM){
+  orgWTad_horz <- function(xy, m = mm - as.numeric(as.vector(hic_dat[1, 1])) + 1
+                           , M = MM - as.numeric(as.vector(hic_dat[1, 1])) + 1){
     ind1 = which(xy[, 1]>= m & xy[, 1]<= M)
     if(length(ind1) <= 1) return(NULL)
     xy = xy[ind1, ]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ and In R type:
 ```
 install.packages('path to rGMAP_1.3.1.tar.gz', type = 'source', rep = NULL)
 ```
+
+## Note
+* The latest *rGMAP* needs R version 3.5.0 or later
+
 ## Input
 * For a single chromosome, a HiC contact matrix *hic_mat* supports three types of format: 
   1. a 3-column Hi-C contact matrix, corresponding to the i_th, j_th bin of a chromosom and the contact number; 


### PR DESCRIPTION
Hey Wenbao, there was a bug when plotting TADs when looking at other chromosomes, where the bin number of the first bin of that chromosome is not 1.
For example, when plotting TADs on chromosome 3, the first bin number of chromosome 3 is 7322 at 40kb resolution in my case. The plotting function would calculate the x axis scale(MB) as 7322/(1000000/40000) = 292.88, so the x scale is starting from 292MB, which should be 0MB.
So I fixed it by accounting the first bin num of current chromosome as you can see in the changed code.

The other change is plotting the black line, which shows the TADs, same problem and I've fixed it in the same way.